### PR TITLE
Add setBuffer() method to OutputMessage class

### DIFF
--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -814,6 +814,7 @@ void Application::registerLuaFunctions()
     // OutputMessage
     g_lua.registerClass<OutputMessage>();
     g_lua.bindClassStaticFunction<OutputMessage>("create", []{ return OutputMessagePtr(new OutputMessage); });
+    g_lua.bindClassMemberFunction<OutputMessage>("setBuffer", &OutputMessage::setBuffer);
     g_lua.bindClassMemberFunction<OutputMessage>("getBuffer", &OutputMessage::getBuffer);
     g_lua.bindClassMemberFunction<OutputMessage>("reset", &OutputMessage::reset);
     g_lua.bindClassMemberFunction<OutputMessage>("addU8", &OutputMessage::addU8);

--- a/src/framework/net/outputmessage.cpp
+++ b/src/framework/net/outputmessage.cpp
@@ -35,6 +35,16 @@ void OutputMessage::reset()
     m_messageSize = 0;
 }
 
+void OutputMessage::setBuffer(const std::string& buffer)
+{
+    int len = buffer.size();
+    checkWrite(MAX_HEADER_SIZE + len);
+    memcpy(m_buffer + MAX_HEADER_SIZE, buffer.c_str(), len);
+    m_writePos = MAX_HEADER_SIZE;
+    m_headerPos = MAX_HEADER_SIZE;
+    m_messageSize = len;
+}
+
 void OutputMessage::addU8(uint8 value)
 {
     checkWrite(1);

--- a/src/framework/net/outputmessage.h
+++ b/src/framework/net/outputmessage.h
@@ -40,6 +40,7 @@ public:
 
     void reset();
 
+    void setBuffer(const std::string& buffer);
     std::string getBuffer() { return std::string((char*)m_buffer + m_headerPos, m_messageSize); }
 
     void addU8(uint8 value);


### PR DESCRIPTION
This method similar to method setBuffer of InputMessage class will able to easy data copy from one OutputMessage/InputMessage to other.

May be helpful for make cast system using TCP/IP protocol.