### PR TITLE
Use gameLeftPanel as gameRightPanel

### DIFF
--- a/modules/corelib/ui/uiminiwindowcontainer.lua
+++ b/modules/corelib/ui/uiminiwindowcontainer.lua
@@ -9,6 +9,20 @@ function UIMiniWindowContainer.create()
   return container
 end
 
+function UIMiniWindowContainer:getEmptySpaceHeight()
+  local sumHeight = 0
+  local children = self:getChildren()
+
+  for i=1,#children do
+    if children[i]:isVisible() then
+      sumHeight = sumHeight + children[i]:getHeight()
+    end
+  end
+  local selfHeight = self:getHeight() - (self:getPaddingTop() + self:getPaddingBottom())
+
+  return selfHeight - sumHeight
+end
+
 -- TODO: connect to window onResize event
 -- TODO: try to resize another widget?
 -- TODO: try to find another panel?
@@ -78,12 +92,16 @@ function UIMiniWindowContainer:fitAll(noRemoveChild)
 
   -- close widgets
   for i=1,#removeChildren do
-    removeChildren[i]:close()
+    signalcall(removeChildren[i].onRemoveFromContainer, removeChildren[i])
+    
+    if removeChildren[i]:getParent():getId() == self:getId() then
+      removeChildren[i]:close()
+    end
   end
 end
 
 function UIMiniWindowContainer:onDrop(widget, mousePos)
-  if widget:getClassName() == 'UIMiniWindow' then
+  if widget.UIMiniWindowContainer then
     local oldParent = widget:getParent()
     if oldParent == self then
       return true

--- a/modules/game_containers/containers.lua
+++ b/modules/game_containers/containers.lua
@@ -85,7 +85,7 @@ function onContainerOpen(container, previousContainer)
     previousContainer.window = nil
     previousContainer.itemsPanel = nil
   else
-    containerWindow = g_ui.createWidget('ContainerWindow', modules.game_interface.getRightPanel())
+    containerWindow = g_ui.createWidget('ContainerWindow')
   end
   containerWindow:setId('container' .. container:getId())
   local containerPanel = containerWindow:getChildById('contentsPanel')
@@ -138,6 +138,10 @@ function onContainerOpen(container, previousContainer)
   if not previousContainer then
     local filledLines = math.max(math.ceil(container:getItemsCount() / layout:getNumColumns()), 1)
     containerWindow:setContentHeight(filledLines*cellSize.height)
+  end
+
+  if not previousContainer then
+    modules.game_interface.addToPanels(containerWindow)
   end
 
   containerWindow:setup()

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -362,6 +362,30 @@ function updateStretchShrink()
   end
 end
 
+function addToPanels(uiWidget)
+  uiWidget.onRemoveFromContainer = function(widget)
+    if gameLeftPanel:isOn() then
+      if widget:getParent():getId() == 'gameRightPanel' then
+        if gameLeftPanel:getEmptySpaceHeight() - widget:getHeight() >= 0 then
+          widget:setParent(gameLeftPanel)
+        end
+      elseif widget:getParent():getId() == 'gameLeftPanel' then
+        if gameRightPanel:getEmptySpaceHeight() - widget:getHeight() >= 0 then
+          widget:setParent(gameRightPanel)
+        end
+      end
+    end
+  end
+
+  if not gameLeftPanel:isOn() then uiWidget:setParent(gameRightPanel) return end
+
+  if gameRightPanel:getEmptySpaceHeight() - uiWidget:getHeight() >= 0 then
+    uiWidget:setParent(gameRightPanel)
+  else
+    uiWidget:setParent(gameLeftPanel)
+  end
+end
+
 function onMouseGrabberRelease(self, mousePosition, mouseButton)
   if selectedThing == nil then return false end
   if mouseButton == MouseLeftButton then

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -377,7 +377,10 @@ function addToPanels(uiWidget)
     end
   end
 
-  if not gameLeftPanel:isOn() then uiWidget:setParent(gameRightPanel) return end
+  if not gameLeftPanel:isOn() then
+    uiWidget:setParent(gameRightPanel)
+    return
+  end
 
   if gameRightPanel:getEmptySpaceHeight() - uiWidget:getHeight() >= 0 then
     uiWidget:setParent(gameRightPanel)


### PR DESCRIPTION
It's provide to use gameLeftPanel (if it's ON) like gameRightPanel, by using function addToPanels().

When gameRightPanel is full:
![](https://user-images.githubusercontent.com/29635365/41494196-581405dc-7110-11e8-91e0-7231d9d06638.gif)

When in gameRightPanel one window is resized (now windows it's moved to gameLeftPanel, normal it's would be removed):
![](https://user-images.githubusercontent.com/29635365/41494239-da27c25c-7110-11e8-8d88-b8e6704baf9a.gif)

New functions:
[modules.game_interface] addToPanels(<UIWidget>) - they set uiminiwindow in gameRightPanel or in gameLeftPanel (according on free place) priority gameRightPanel [function may set uiminiwindow to gameLeftPanel only when it's ON], additional they moved (if find free place in gameRightPanel or gameLeftPanel) window when we add other uiminiwindow or resize one from them when uiminiwindowcontainer is full (instead remove) to other Panel.

UIMiniWindowContainer:getEmptySpaceHeight() - return height of UIMiniWindowContainer without windows (uiminiwindow), who we may set to other windows.

New signals (signalcall):
UIMiniWindowContainer.onRemoveFromContainer [<UIWidget>] - return UIWidget who want to be removed (before deleted who provide to set operation to stopped deleted this UIWidget [change parent]) from UIMiniWindowContainer (by UIMiniWindowContainer:fitAll()).