### PR TITLE
Container Window Resizing

### DIFF
--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -346,6 +346,10 @@ function UIMiniWindow:setHeight(height)
   signalcall(self.onHeightChange, self, height)
 end
 
+function UIMiniWindow:getContentHeight()
+  return self:getChildById('contentsPanel'):getHeight()
+end
+
 function UIMiniWindow:setContentHeight(height)
   local contentsPanel = self:getChildById('contentsPanel')
   local minHeight = contentsPanel:getMarginTop() + contentsPanel:getMarginBottom() + contentsPanel:getPaddingTop() + contentsPanel:getPaddingBottom()

--- a/modules/game_containers/containers.lua
+++ b/modules/game_containers/containers.lua
@@ -133,6 +133,9 @@ function onContainerOpen(container, previousContainer)
   local layout = containerPanel:getLayout()
   local cellSize = layout:getCellSize()
   containerWindow:setContentMinimumHeight(cellSize.height)
+  if containerWindow:getContentHeight() < cellSize.height then
+    containerWindow:setContentHeight(cellSize.height)
+  end
   containerWindow:setContentMaximumHeight(cellSize.height*layout:getNumLines())
 
   if not previousContainer then


### PR DESCRIPTION
Resizes container window when content minimum height is greater than current height. For instance when you open a window with the pages tab it will change the the height to match the minimum height.

This commit matches the behavior of real tibia client.

![container_window_fix](https://user-images.githubusercontent.com/43316702/51779531-e8f4f000-20d5-11e9-91ad-fa9a455a8d89.gif)


