### PR TITLE
Fix drawing all floors on minimap

### DIFF
--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -21,6 +21,7 @@
  */
 
 
+#include "game.h"
 #include "minimap.h"
 #include "tile.h"
 
@@ -206,8 +207,15 @@ void Minimap::updateTile(const Position& pos, const TilePtr& tile)
     if(minimapTile != MinimapTile()) {
         MinimapBlock& block = getBlock(pos);
         Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
-        block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
-        block.justSaw();
+		LocalPlayerPtr localPlayer = g_game.getLocalPlayer();
+		if (localPlayer == nullptr) {
+			return;
+		}
+		short playerPosZ = localPlayer->getPosition().z;
+		if (playerPosZ == pos.z) {
+			block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
+			block.justSaw();
+		}
     }
 }
 

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -207,15 +207,15 @@ void Minimap::updateTile(const Position& pos, const TilePtr& tile)
     if(minimapTile != MinimapTile()) {
         MinimapBlock& block = getBlock(pos);
         Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
-		LocalPlayerPtr localPlayer = g_game.getLocalPlayer();
-		if (localPlayer == nullptr) {
-			return;
-		}
-		short playerPosZ = localPlayer->getPosition().z;
-		if (playerPosZ == pos.z) {
-			block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
-			block.justSaw();
-		}
+        LocalPlayerPtr localPlayer = g_game.getLocalPlayer();
+        if (localPlayer == nullptr) {
+            return;
+        }
+        short playerPosZ = localPlayer->getPosition().z;
+        if (playerPosZ == pos.z) {
+            block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
+            block.justSaw();
+        }
     }
 }
 


### PR DESCRIPTION
Fix drawing all floors on minimap

closes https://github.com/otland/otclient/issues/10

Based on @LordHepipud https://github.com/edubart/otclient/pull/595

While still all tiles are received from the server, only the visible ones on the same floor as the player including tiles inside the view range will be drawn.