### PR TITLE
Added option to fix windows on panels

### DIFF
--- a/modules/client_options/game.otui
+++ b/modules/client_options/game.otui
@@ -27,6 +27,10 @@ Panel
     !text: tr('Show left panel')
 
   OptionCheckBox
+    id: moveWindowsToPanel
+    !text: tr('Move windows to panel')
+
+  OptionCheckBox
     id: displayNames
     !text: tr('Display creature names')
 

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -15,6 +15,7 @@ local defaultOptions = {
   showPrivateMessagesInConsole = true,
   showPrivateMessagesOnScreen = true,
   showLeftPanel = false,
+  moveWindowsToPanel = false,
   foregroundFrameRate = 61,
   backgroundFrameRate = 201,
   painterEngine = 0,
@@ -203,6 +204,8 @@ function setOption(key, value, force)
     audioPanel:getChildById('musicSoundVolumeLabel'):setText(tr('Music volume: %d', value))
   elseif key == 'showLeftPanel' then
     modules.game_interface.getLeftPanel():setOn(value)
+  elseif key == 'moveWindowsToPanel' then
+    g_settings.set('moveWindowsToPanel', true)
   elseif key == 'backgroundFrameRate' then
     local text, v = value, value
     if value <= 0 or value >= 201 then text = 'max' v = 0 end

--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -162,15 +162,42 @@ function UIMiniWindow:onDragEnter(mousePos)
 end
 
 function UIMiniWindow:onDragLeave(droppedWidget, mousePos)
-  if self.movedWidget then
-    self.setMovedChildMargin(self.movedOldMargin or 0)
-    self.movedWidget = nil
-    self.setMovedChildMargin = nil
-    self.movedOldMargin = nil
-    self.movedIndex = nil
-  end
 
-  self:saveParent(self:getParent())
+    if g_settings.getBoolean('moveWindowsToPanel') then
+        local children = rootWidget:recursiveGetChildrenByMarginPos(mousePos)
+        local dropInPanel = 0
+     
+        for i=1,#children do
+            local child = children[i]
+            if child:getId() == 'gameLeftPanel' or child:getId() == 'gameRightPanel' then
+                dropInPanel = 1
+            end
+        end
+
+        if dropInPanel == 0 then
+            tmpp = self
+                if(modules.game_interface.getLeftPanel():isVisible()) then
+                    if modules.game_interface.getRootPanel():getWidth() / 2 < mousePos.x then
+                        addEvent(function() tmpp:setParent(modules.game_interface.getRightPanel()) end)
+                    else
+                        addEvent(function() tmpp:setParent(modules.game_interface.getLeftPanel()) end)
+                    end
+                else
+                    addEvent(function() tmpp:setParent(modules.game_interface.getRightPanel()) end)
+            end
+        end
+     
+    else
+        if self.movedWidget then
+          self.setMovedChildMargin(self.movedOldMargin or 0)
+          self.movedWidget = nil
+          self.setMovedChildMargin = nil
+          self.movedOldMargin = nil
+          self.movedIndex = nil
+        end
+     
+        self:saveParent(self:getParent())
+    end
 end
 
 function UIMiniWindow:onDragMove(mousePos, mouseMoved)


### PR DESCRIPTION
Now you can select if the windows (battle, vip, inventory, map, etc) should be fixed on panels or can be free on screen.

https://otland.net/threads/mod-windows-bp-eq-battle-etc-can-be-dragged-only-to-panels-right-left.233809/