### PR TITLE
 Poor fix for creature dashing/teleporting to next tile when walking

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -906,7 +906,11 @@ int Creature::getStepDuration(bool ignoreDiagonal, Otc::Direction dir)
        m_lastStepDirection == Otc::SouthWest || m_lastStepDirection == Otc::SouthEast))
         interval *= factor;
 
-    return interval;
+    if (this->isLocalPlayer()) {
+		return interval;
+	}
+
+    return (int)interval*0.8f;
 }
 
 Point Creature::getDisplacement()

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -906,7 +906,7 @@ int Creature::getStepDuration(bool ignoreDiagonal, Otc::Direction dir)
        m_lastStepDirection == Otc::SouthWest || m_lastStepDirection == Otc::SouthEast))
         interval *= factor;
 
-    if(g_game.getClientVersion() >= 1098 && !this->isLocalPlayer) {
+    if(g_game.getClientVersion() >= 1098 && !this->isLocalPlayer()) {
         return (int)interval*0.8f;
     }
     

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -906,11 +906,11 @@ int Creature::getStepDuration(bool ignoreDiagonal, Otc::Direction dir)
        m_lastStepDirection == Otc::SouthWest || m_lastStepDirection == Otc::SouthEast))
         interval *= factor;
 
-    if (this->isLocalPlayer()) {
-		return interval;
-	}
-
-    return (int)interval*0.8f;
+    if(g_game.getClientVersion() >= 1098 && !this->isLocalPlayer) {
+        return (int)interval*0.8f;
+    }
+    
+    return interval;
 }
 
 Point Creature::getDisplacement()


### PR DESCRIPTION
Decreasing the return value from getStepDuration() on creature.cpp minimizes the dashing/teleporting issue when walking to next tile.