### PR TITLE
Fix for sprite lagging when pushing creatures to diagonal

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -899,6 +899,9 @@ int Creature::getStepDuration(bool ignoreDiagonal, Otc::Direction dir)
     float factor = 3;
     if(g_game.getClientVersion() <= 810)
         factor = 2;
+    
+    if(g_game.getClientVersion() >= 1098)
+        factor = 1;
 
     interval = std::max<int>(interval, g_game.getServerBeat());
 


### PR DESCRIPTION
I don't know if this is right but it solves the problem. You can set factor to 1.5 too, don't know which is better.