### PR TITLE
Idle Animations & Animate Always Fix

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -514,8 +514,8 @@ void Creature::updateWalkAnimation(int totalPixelsWalked)
     int footDelay = getStepDuration(true) / getAnimationPhases() + 15;
     if (m_outfit.getMount() != 0) {
         auto datType = g_things.rawGetThingType(m_outfit.getMount(), ThingCategoryCreature);
+        footAnimPhases = datType->getAnimationPhases() - 1;
         if (datType->getIdleAnimator() != nullptr) {
-            footAnimPhases = datType->getAnimationPhases();
             footDelay = getStepDuration(true) / ceil(footAnimPhases / 2) + 15;
         }
     } else if (getIdleAnimator() != nullptr) {
@@ -523,10 +523,6 @@ void Creature::updateWalkAnimation(int totalPixelsWalked)
     }
 
     // Since mount is a different outfit we need to get the mount animation phases
-    if(m_outfit.getMount() != 0) {
-        ThingType *type = g_things.rawGetThingType(m_outfit.getMount(), m_outfit.getCategory());
-        footAnimPhases = type->getAnimationPhases() - 1;
-    }
     if(footAnimPhases == 0)
         m_walkAnimationPhase = 0;
     else if(m_footStepDrawn && m_footTimer.ticksElapsed() >= footDelay && totalPixelsWalked < 32) {

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -75,6 +75,7 @@ public:
     int getNumPatternZ() { return rawGetThingType()->getNumPatternZ(); }
     int getAnimationPhases() { return rawGetThingType()->getAnimationPhases(); }
     AnimatorPtr getAnimator() { return rawGetThingType()->getAnimator(); }
+    AnimatorPtr getIdleAnimator() { return rawGetThingType()->getIdleAnimator(); }
     int getGroundSpeed() { return rawGetThingType()->getGroundSpeed(); }
     int getMaxTextLength() { return rawGetThingType()->getMaxTextLength(); }
     Light getLight() { return rawGetThingType()->getLight(); }

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -301,8 +301,17 @@ void ThingType::unserialize(uint16 clientId, ThingCategory category, const FileS
         m_animationPhases += groupAnimationsPhases;
 
         if(groupAnimationsPhases > 1 && g_game.getFeature(Otc::GameEnhancedAnimations)) {
-            m_animator = AnimatorPtr(new Animator);
-            m_animator->unserialize(groupAnimationsPhases, fin);
+            AnimatorPtr animator = AnimatorPtr(new Animator);
+            animator->unserialize(groupAnimationsPhases, fin);
+
+            switch(frameGroupType) {
+                case FrameGroupIdle:
+                    m_idleAnimator = animator;
+                    break;
+                case FrameGroupMoving:
+                    m_animator = animator;
+                    break;
+            }
         }
 
         int totalSprites = m_size.area() * m_layers * m_numPatternX * m_numPatternY * m_numPatternZ * groupAnimationsPhases;
@@ -317,6 +326,11 @@ void ThingType::unserialize(uint16 clientId, ThingCategory category, const FileS
         totalSpritesCount += totalSprites;
     }
 
+    if(m_idleAnimator && !m_animator) {
+        m_animator = m_idleAnimator;
+        m_idleAnimator = nullptr;
+    }
+    
     m_textures.resize(m_animationPhases);
     m_texturesFramesRects.resize(m_animationPhases);
     m_texturesFramesOriginRects.resize(m_animationPhases);

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -149,6 +149,7 @@ public:
     int getNumPatternZ() { return m_numPatternZ; }
     int getAnimationPhases() { return m_animationPhases; }
     AnimatorPtr getAnimator() { return m_animator; }
+    AnimatorPtr getIdleAnimator() { return m_idleAnimator; }
     Point getDisplacement() { return m_displacement; }
     int getDisplacementX() { return getDisplacement().x; }
     int getDisplacementY() { return getDisplacement().y; }
@@ -222,6 +223,7 @@ private:
     Size m_size;
     Point m_displacement;
     AnimatorPtr m_animator;
+    AnimatorPtr m_idleAnimator;
     int m_animationPhases;
     int m_exactSize;
     int m_realSize;


### PR DESCRIPTION
- Added idle animations and fixed bug that occurs when animations for creature and mount are different. 
- Outfit animators combine idle and walking animation when idle has an animation, so I compensated by changing the way the animation phases are preformed. 
- Changed the way step duration is handled for these idle animating outfits to look more smooth like the other outfits.
- Added a section to always get animation when AnimateAlways is present.

Parts of this commit include the fixes from @ninjalulz.

![test1](https://user-images.githubusercontent.com/43316702/53865434-2f831780-3fbd-11e9-811e-ce88398f22f9.gif)
