### PR TITLE
Fix compilation errors with makeScreenShot

### DIFF
--- a/src/framework/platform/platformwindow.cpp
+++ b/src/framework/platform/platformwindow.cpp
@@ -247,5 +247,5 @@ void PlatformWindow::makeScreenShot(std::string file) {
 
     glReadPixels(0, 0, getWidth(), getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 
-    boost::thread thread = boost::thread(&PlatformWindow::changeScreenShotOrientation, this, pixels, arrayLength, widthLength, heightLength, file);
+    boost::thread(&PlatformWindow::changeScreenShotOrientation, this, pixels, arrayLength, widthLength, heightLength, file);
 }


### PR DESCRIPTION
After adding `makeScreenShot`, new errors appeared when compiling. Easy fix for this.

```
1>libboost_thread-vc140-mt-1_63.lib(thread.obj) : error LNK2005: "public: virtual __cdecl boost::detail::thread_data_base::~thread_data_base(void)" (??1thread_data_base@detail@boost@@UEAA@XZ) already defined in boost_thread-vc140-mt.lib(boost_thread-vc141-mt-x64-1_68.dll)
1>libboost_thread-vc140-mt-1_63.lib(thread.obj) : error LNK2005: "public: void __cdecl boost::thread::detach(void)" (?detach@thread@boost@@QEAAXXZ) already defined in boost_thread-vc140-mt.lib(boost_thread-vc141-mt-x64-1_68.dll)
1>libboost_thread-vc140-mt-1_63.lib(thread.obj) : error LNK2005: "private: bool __cdecl boost::thread::start_thread_noexcept(void)" (?start_thread_noexcept@thread@boost@@AEAA_NXZ) already defined in boost_thread-vc140-mt.lib(boost_thread-vc141-mt-x64-1_68.dll)
1>D:\Main Files\Tibia\Work\FrozenApocalypse\otclient-master\vc14\../build/otclient.exe : fatal error LNK1169: one or more multiply defined symbols found
1>Done building project "otclient.vcxproj" -- FAILED.
========== Rebuild All: 0 succeeded, 1 failed, 0 skipped ==========
```