### PR TITLE
Add function removeTab

### DIFF
--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -272,3 +272,7 @@ end
 function addButton(name, func, icon)
   optionsTabBar:addButton(name, func, icon)
 end
+
+function removeTab(name)
+  optionsTabBar:removeTab(optionsTabBar:getTab(name))
+end


### PR DESCRIPTION
Function to delete dynamic tabs from external modules.
Dynamic tabs in option panel may be useful to add option for modules without GUI.

Usage:
```
--Add new tab to options module
function init()
  optionPanel = g_ui.loadUI('option_healthcircle')
  modules.client_options.addTab(tr('Hp Mp Circle'), optionPanel, '/game_healthcircle/img_game_healthcircle/hp_mp_circle')
end

--Remove new tab from options module
function terminate()
  --Additionally need to delete references to UI here
  modules.client_options.removeTab('Hp Mp Circle')
end
```

Example: new external module options in options module.
![options_hp_mp_circle_2](https://user-images.githubusercontent.com/29635365/57199944-61950380-6f85-11e9-8594-97d93c1a3d7f.png)
