### PR TITLE
Removed targets static square fix

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -519,8 +519,12 @@ void Game::processModalDialog(uint32 id, std::string title, std::string message,
 
 void Game::processAttackCancel(uint seq)
 {
-    if(isAttacking() && (seq == 0 || m_seq == seq))
-        cancelAttack();
+    if(seq == 0 || m_seq == seq) {
+        if(isAttacking())
+            cancelAttack();
+        else
+            setAttackingCreature(nullptr);
+    }
 }
 
 void Game::processWalkCancel(Otc::Direction direction)


### PR DESCRIPTION
Fix for this issue:
https://github.com/edubart/otclient/issues/575

Problem is Creature::onDisappear removes the creature before the sendCancelTarget is sent from server. So when the removed creature re-appears it is still registered as m_attackingCreature and the static square is re-drawn.