### PR TITLE
Cleanup + make otc compilable out of the box

### DIFF
--- a/src/framework/luaengine/lbitlib.cpp
+++ b/src/framework/luaengine/lbitlib.cpp
@@ -33,8 +33,17 @@
 #define LUA_LIB
 
 extern "C" {
+#if __has_include("luajit/lua.h")
+#include <luajit/lua.h>
+#else
 #include <lua.h>
+#endif
+
+#if __has_include("luajit/lauxlib.h")
+#include <luajit/lauxlib.h>
+#else
 #include <lauxlib.h>
+#endif
 }
 
 /* ----- adapted from lua-5.2.0 luaconf.h: ----- */
@@ -175,11 +184,23 @@ static lua_Unsigned luaL_checkunsigned (lua_State *L, int arg) {
 #define lbitlib_c
 #define LUA_LIB
 
-#include "lua.h"
+#if __has_include("luajit/lua.h")
+#include <luajit/lua.h>
+#else
+#include <lua.h>
+#endif
 
-#include "lauxlib.h"
-#include "lualib.h"
+#if __has_include("luajit/lauxlib.h")
+#include <luajit/lauxlib.h>
+#else
+#include <lauxlib.h>
+#endif
 
+#if __has_include("luajit/lualib.h")
+#include <luajit/lualib.h>
+#else
+#include <lualib.h>
+#endif
 
 /* number of bits to consider in a number */
 #if !defined(LUA_NBITS)

--- a/src/framework/luaengine/luainterface.cpp
+++ b/src/framework/luaengine/luainterface.cpp
@@ -24,7 +24,11 @@
 #include "luaobject.h"
 
 #include <framework/core/resourcemanager.h>
+#if __has_include("luajit/lua.hpp")
+#include <luajit/lua.hpp>
+#else
 #include <lua.hpp>
+#endif
 
 #include "lbitlib.h"
 

--- a/vc14/arch32.props
+++ b/vc14/arch32.props
@@ -4,7 +4,6 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalLibraryDirectories>$(OTCLIENT_LIBS)</AdditionalLibraryDirectories>
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>

--- a/vc14/arch64.props
+++ b/vc14/arch64.props
@@ -2,10 +2,5 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup>
-    <Link>
-      <AdditionalLibraryDirectories>$(OTCLIENT_LIBS64)</AdditionalLibraryDirectories>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemGroup />
 </Project>

--- a/vc14/otclient.vcxproj
+++ b/vc14/otclient.vcxproj
@@ -22,28 +22,28 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{17A8F78F-1FFB-4128-A3B3-59CC6C19D89A}</ProjectGuid>
     <RootNamespace>otclient</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/vc14/register_otclient_boost_env.bat
+++ b/vc14/register_otclient_boost_env.bat
@@ -1,1 +1,0 @@
-setx BOOST_ROOT_OTCLIENT %CD%

--- a/vc14/register_otclient_sdk_env.bat
+++ b/vc14/register_otclient_sdk_env.bat
@@ -1,1 +1,0 @@
-setx OTCLIENTSDKDir %CD%

--- a/vc14/settings.props
+++ b/vc14/settings.props
@@ -2,14 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <LUA_DIR>$(OTCLIENTSDKDir)\LuaJIT-2.1.0\</LUA_DIR>
-    <GLEW_DIR>$(OTCLIENTSDKDir)\glew-2.0.0\</GLEW_DIR>
-    <LIBOGG_DIR>$(OTCLIENTSDKDir)\libogg-1.3.2\</LIBOGG_DIR>
-    <LIBVORBIS_DIR>$(OTCLIENTSDKDir)\libvorbis-1.3.5\</LIBVORBIS_DIR>
-    <OPEN_AL_DIR>$(OTCLIENTSDKDir)\OpenAL-1.15.1\</OPEN_AL_DIR>
-    <OPEN_SSL_DIR>$(OTCLIENTSDKDir)\OpenSSL-1.0.2j\</OPEN_SSL_DIR>
-    <PHYSFS_DIR>$(OTCLIENTSDKDir)\physfs-2.0.3.1\</PHYSFS_DIR>
-    <ZLIB_DIR>$(OTCLIENTSDKDir)\zlib-1.2.8.8\</ZLIB_DIR>
     <PREPROCESSOR_DEFS>WIN32;
         _CRT_SECURE_NO_WARNINGS;
         _WIN32_WINNT=0x0501;
@@ -25,43 +17,10 @@
         BUILD_REVISION="$(BUILD_REVISION)";
         VERSION="$(VERSION)";
         AB</PREPROCESSOR_DEFS>
-    <OTCLIENT_INCLUDES>
-        $(BOOST_ROOT_OTCLIENT);
-        $(LUA_DIR)\include;
-        $(GLEW_DIR)\include;
-        $(LIBOGG_DIR)\include;
-        $(LIBVORBIS_DIR)\include;
-        $(OPEN_AL_DIR)\include;
-        $(OPEN_SSL_DIR)\include;
-        $(PHYSFS_DIR)\include;
-        $(ZLIB_DIR)\include
-    </OTCLIENT_INCLUDES>
-    <OTCLIENT_LIBS>
-        $(BOOST_ROOT_OTCLIENT)\lib32-msvc-14.0;
-        $(LUA_DIR)\lib;
-        $(GLEW_DIR)\lib;
-        $(LIBOGG_DIR)\lib;
-        $(LIBVORBIS_DIR)\lib;
-        $(OPEN_AL_DIR)\lib;
-        $(OPEN_SSL_DIR)\lib;
-        $(PHYSFS_DIR)\lib;
-        $(ZLIB_DIR)\lib
-    </OTCLIENT_LIBS>
-    <OTCLIENT_LIBS64>
-        $(BOOST_ROOT_OTCLIENT)\lib64-msvc-14.0;
-        $(LUA_DIR)\lib64;
-        $(GLEW_DIR)\lib64;
-        $(LIBOGG_DIR)\lib64;
-        $(LIBVORBIS_DIR)\lib64;
-        $(OPEN_AL_DIR)\lib64;
-        $(OPEN_SSL_DIR)\lib64;
-        $(PHYSFS_DIR)\lib64;
-        $(ZLIB_DIR)\lib64
-    </OTCLIENT_LIBS64>
     <OTCLIENT_LIBDEPS>
         glew32.lib;
         zlib.lib;
-        libeay32.lib;
+        libcrypto.lib;
         physfs.lib;
         openal32.lib;
         lua51.lib;
@@ -79,7 +38,7 @@
     <OTCLIENT_LIBDEPS_D>
         glew32d.lib;
         zlibd.lib;
-        libeay32.lib;
+        libcrypto.lib;
         physfs.lib;
         openal32.lib;
         lua51.lib;
@@ -104,7 +63,6 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(OTCLIENT_INCLUDES)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -124,52 +82,8 @@
     </ResourceCompile> -->
   </ItemDefinitionGroup>
   <ItemGroup>
-    <BuildMacro Include="LUA_DIR">
-      <Value>$(LUA_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="GLEW_DIR">
-      <Value>$(GLEW_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="LIBOGG_DIR">
-      <Value>$(LIBOGG_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="LIBVORBIS_DIR">
-      <Value>$(LIBVORBIS_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="OPEN_AL_DIR">
-      <Value>$(OPEN_AL_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="OPEN_SSL_DIR">
-      <Value>$(OPEN_SSL_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="PHYSFS_DIR">
-      <Value>$(PHYSFS_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="ZLIB_DIR">
-      <Value>$(ZLIB_DIR)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
     <BuildMacro Include="PREPROCESSOR_DEFS">
       <Value>$(PREPROCESSOR_DEFS)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="OTCLIENT_INCLUDES">
-      <Value>$(OTCLIENT_INCLUDES)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="OTCLIENT_LIBS">
-      <Value>$(OTCLIENT_LIBS)</Value>
-      <EnvironmentVariable>true</EnvironmentVariable>
-    </BuildMacro>
-    <BuildMacro Include="OTCLIENT_LIBS64">
-      <Value>$(OTCLIENT_LIBS64)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
     <BuildMacro Include="OTCLIENT_LIBDEPS">


### PR DESCRIPTION
Like the tilte says, we have some unneeded files in the repository and otc does not compile straight up after downloading files and installing libs. I have also removed some unused macros from times when we used tfs sdk