### PR TITLE
[creature] fix for laggy diagonal animation

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -606,14 +606,14 @@ void Creature::nextWalkUpdate()
         m_walkUpdateEvent = g_dispatcher.scheduleEvent([self] {
             self->m_walkUpdateEvent = nullptr;
             self->nextWalkUpdate();
-        }, getStepDuration() / 32);
+        }, getStepDuration(true) / 32);
     }
 }
 
 void Creature::updateWalk()
 {
     float walkTicksPerPixel = getStepDuration(true) / 32;
-    int totalPixelsWalked = std::min<int>(m_walkTimer.ticksElapsed() / walkTicksPerPixel, 32.0f);
+    int totalPixelsWalked = std::min<int>(m_walkTimer.ticksElapsed() / walkTicksPerPixel, 32);
 
     // needed for paralyze effect
     m_walkedPixels = std::max<int>(m_walkedPixels, totalPixelsWalked);


### PR DESCRIPTION
proper fix for this long standing bug.

there are two interesting lines 609 and 615
609 controls how often creature should update it's internal offset from default tile position
615 controls (based on the speed and tile type) how much creature moved from previous time this function was called.

creators of previous solutions seemed to not care that this bug is only happening when moving diagonally and they was just changing global update rate

there are 4 different combination for this two method:
first column is for 609 line getStepDuration and second for 615

false / false
slower refresh when diagonal / slower movement speed when diagonal

false / true
slower refresh when diagonal / normal movement speed when diagonal

true / false:
normal refresh when diagonal / slower movement speed when diagonal

true / true:
normal refresh when diagonal / normal movement speed when diagonal

basically the false true is the worst option because it leaves movement speed as is and slower the position update rate

I don't remember how official tibia client looks like but the two _sane_ options are
false / false
true / true

where true / true leaves speed as is(but there is longer period of time at the end when no movement is posible and the creature is not moving)

and false / false which adapt the movement speed when diagonal to be a little slower compared to nomal but the waiting period at the end of movement is shorter

there is no point in increasing refreshing period to much because event dispatcher granularity is only 1 ms. which is weird because is only the problem of event and scheduler interface and not the underlying clock interface which gives more granularity

and frame time for 60 fps is 16.(6) ms so more granularity than 1 ms would be good it seams to me