### PR TITLE
Add possibility to add actions for hotkeys.

### DIFF
--- a/modules/game_hotkeys/hotkeys_manager.otui
+++ b/modules/game_hotkeys/hotkeys_manager.otui
@@ -11,7 +11,7 @@ HotkeyListLabel < UILabel
 MainWindow
   id: hotkeysWindow
   !text: tr('Hotkeys')
-  size: 340 410
+  size: 340 445
 
   @onEnter: modules.game_hotkeys.ok()
   @onEscape: modules.game_hotkeys.cancel()
@@ -157,6 +157,25 @@ MainWindow
     checked: false
     margin-top: 2
 
+  Button
+    id: hotkeyAction
+    !text: tr('Add action')
+    width: 128
+    enabled: false
+    anchors.left: parent.left
+    anchors.top: prev.bottom
+    margin-top: 8
+    @onClick: modules.game_hotkeys.startChooseAction()
+
+  Button
+    id: clearAction
+    !text: tr('Clear action')
+    width: 128
+    enabled: false
+    anchors.right: parent.right
+    anchors.top: prev.top
+    @onClick: modules.game_hotkeys.clearObject()
+
   HorizontalSeparator
     id: separator
     anchors.left: parent.left
@@ -202,6 +221,53 @@ HotkeyAssignWindow < MainWindow
     anchors.top: prev.bottom
     margin-top: 10
     text-auto-resize: true
+
+  HorizontalSeparator
+    id: separator
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: next.top
+    margin-bottom: 10
+
+  Button
+    id: addButton
+    !text: tr('Add')
+    width: 64
+    anchors.right: next.left
+    anchors.bottom: parent.bottom
+    margin-right: 10
+    @onClick: modules.game_hotkeys.hotkeyCaptureOk(self:getParent(), self:getParent():getChildById('comboPreview').keyCombo)
+
+  Button
+    id: cancelButton
+    !text: tr('Cancel')
+    width: 64
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    @onClick: self:getParent():destroy()
+
+HotkeyActionWindow < MainWindow
+  id: actionWindow
+  !text: tr('Button Action')
+  size: 230 150
+  @onEscape: self:destroy()
+
+  ComboBox
+    id: modComboBox
+    width: 200
+    anchors.left: parent.left
+    anchors.top: parent.top
+    margin-top: 5
+    mouse-scroll: false
+
+  ComboBox
+    id: actionComboBox
+    width: 200
+    enabled: false
+    anchors.left: parent.left
+    anchors.top: prev.bottom
+    margin-top: 5
+    mouse-scroll: false
 
   HorizontalSeparator
     id: separator


### PR DESCRIPTION
System for binding predefined actions with hotkeys module.

**Api for external mods/modules.**

_Add action to action list:_
`modules.game_hotkeys.addAction(moduleName, actionName, function)`

_Remove action from action list:_
`modules.game_hotkeys.removeAction(moduleName, actionName)`
or for all module actions:
`modules.game_hotkeys.removeAction(moduleName)`

How it's look in game_hotkeys module (new buttons "Add action" / "Clear action", new hotkey type "Action"):
![image](https://user-images.githubusercontent.com/29635365/83562699-4dba2900-a51a-11ea-89c7-255d2f21efc2.png)

List with actions:
![image](https://user-images.githubusercontent.com/29635365/83562741-5f9bcc00-a51a-11ea-9d80-4645ab6cb387.png)

* Added first action - [game_hotkeys] [toggle] - toggle hotkeys window.

Limitations:
* To add action, mod/module must be load after game_hotkeys module.
* Module game_hotkeys works only after login to game.