### PR TITLE
change stdext::packet_vector to std::vector

### DIFF
--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -132,9 +132,9 @@ public:
 private:
     void checkTranslucentLight();
 
-    stdext::packed_vector<CreaturePtr> m_walkingCreatures;
-    stdext::packed_vector<EffectPtr> m_effects; // leave this outside m_things because it has no stackpos.
-    stdext::packed_vector<ThingPtr> m_things;
+    std::vector<CreaturePtr> m_walkingCreatures;
+    std::vector<EffectPtr> m_effects; // leave this outside m_things because it has no stackpos.
+    std::vector<ThingPtr> m_things;
     Position m_position;
     uint8 m_drawElevation;
     uint8 m_minimapColor;

--- a/src/framework/stdext/stdext.h
+++ b/src/framework/stdext/stdext.h
@@ -35,7 +35,6 @@
 #include "math.h"
 #include "packed_any.h"
 #include "packed_storage.h"
-#include "packed_vector.h"
 #include "shared_object.h"
 #include "string.h"
 #include "time.h"


### PR DESCRIPTION
we don't use _more_ memory by doing so but it can improve fps drop when many thing are happening on screen in the same time, because we reuse alocated memory insted of freeing it and alocating again.

packet_vector is copying data over on every push and erase because it always alocate new chunk of memory